### PR TITLE
GitHub workflows fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,9 @@ name: Build Express Application
 
 on:
   push:
-    branches: [master]
+    branches: [master]  # Ensure consistency in branch naming.
   pull_request:
+    branches: [master]  # Run checks on pull requests targeting the 'master' branch.
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build Express Application
 
 on:
   push:
-    branches: [master]  # Ensure consistency in branch naming.
+    branches: [master]
   pull_request:
-    branches: [master]  # Run checks on pull requests targeting the 'master' branch.
+    branches: [master]
 
 jobs:
   build:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,9 +2,9 @@ name: Docker Image CI
 
 on:
   push:
-    branches: ['master']  # Ensure consistency here
+    branches: ['master']
   pull_request:
-    branches: ['master']  # Specify target branches
+    branches: ['master']
 
 jobs:
   build:
@@ -13,7 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Login step only executed for pushes to master
       - name: Login to GitHub Container Registry
         if: github.ref == 'refs/heads/master'
         uses: docker/login-action@v3
@@ -22,7 +21,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GH_Token }}
 
-      # Build step with dynamic tagging
       - name: Build the Docker image
         run: |
           docker build . --file Dockerfile --tag ghcr.io/${{ github.repository }}:${{ github.sha }}
@@ -30,7 +28,6 @@ jobs:
             docker tag ghcr.io/${{ github.repository }}:${{ github.sha }} ghcr.io/${{ github.repository }}:latest
           fi
 
-      # Push step only executed for pushes to master
       - name: Push the Docker image
         if: github.ref == 'refs/heads/master'
         run: |

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,8 +2,9 @@ name: Docker Image CI
 
 on:
   push:
-    branches: ['master']
+    branches: ['master']  # Ensure consistency here
   pull_request:
+    branches: ['master']  # Specify target branches
 
 jobs:
   build:
@@ -12,9 +13,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Login step only executed for pushes to main
+      # Login step only executed for pushes to master
       - name: Login to GitHub Container Registry
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/master'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -25,13 +26,13 @@ jobs:
       - name: Build the Docker image
         run: |
           docker build . --file Dockerfile --tag ghcr.io/${{ github.repository }}:${{ github.sha }}
-          if [ "${{ github.ref }}" == "refs/heads/main" ]; then
+          if [ "${{ github.ref }}" == "refs/heads/master" ]; then
             docker tag ghcr.io/${{ github.repository }}:${{ github.sha }} ghcr.io/${{ github.repository }}:latest
           fi
 
-      # Push step only executed for pushes to main
+      # Push step only executed for pushes to master
       - name: Push the Docker image
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/master'
         run: |
           docker push ghcr.io/${{ github.repository }}:${{ github.sha }}
           docker push ghcr.io/${{ github.repository }}:latest


### PR DESCRIPTION
Ensure consistency in branch naming ('master' not 'main').
Only run checks on pull requests targeting the 'master' branch. 